### PR TITLE
Improve remote server requests, add ScaFi.js via query parameter

### DIFF
--- a/scafi-web/src/main/resources/config/server.json
+++ b/scafi-web/src/main/resources/config/server.json
@@ -1,1 +1,1 @@
-["antares.apice.unibo.it"]
+["antares.apice.unibo.it", "localhost"]

--- a/scafi-web/src/main/scala/it/unibo/scafi/js/Index.scala
+++ b/scafi-web/src/main/scala/it/unibo/scafi/js/Index.scala
@@ -60,7 +60,13 @@ object Index {
     } else {
       spaPage()
     }
-    scafiInitialization()
+    // to improve, support for ScaFi.js
+    val defaultMode = if (queryParams.has("javascript")) {
+      EditorSection.JavascriptMode
+    } else {
+      EditorSection.ScalaModeEasy
+    }
+    scafiInitialization(defaultMode)
     ThemeSwitcher.render(SkeletonPage.navRightSide) // attach the theme switcher
   }
 
@@ -105,7 +111,7 @@ object Index {
     // TODO add period description
     .andFinally(() => Cookie.store("visited", "true"))
 
-  def scafiInitialization(): Unit = {
+  def scafiInitialization(mode: EditorSection.Mode): Unit = {
     implicit val context: Scheduler = Execution.timeoutBasedScheduler
     // dynamic part configuration
     val interaction = new Interaction.PhaserInteraction(support)
@@ -132,8 +138,6 @@ object Index {
     // force repaint
     support.invalidate()
     SkeletonPage.visualizationSection.focus()
-    PageBus.publish(configuration) // tell to all component the new configuration installed on the frontend
-
     val tour = buildTour(controls).start()
     PopoverProgression.ResetButton.render(tour, SkeletonPage.navRightSide)
     if (!Cookie.get("visited").exists(_.toBoolean)) {
@@ -145,11 +149,16 @@ object Index {
       }
       modal.show()
     }
+    
     PageBus.publish(configuration) //tell to all component the new configuration installed on the frontend
     val example = Seq(BasicExamples(), LibraryExamples(), MatrixLedExample(), MovementExamples(), HighLevelExamples())
     //PageStructure.static()
     PageStructure.resizable()
-    val exampleChooser = new ExampleChooser(SkeletonPage.selectionProgram, example, configurationSection, editor)
+    if(mode == EditorSection.JavascriptMode) {
+      editor.setCode("", mode)
+    } else {
+      val exampleChooser = new ExampleChooser(SkeletonPage.selectionProgram, example, configurationSection, editor)
+    }
   }
   @JSExportTopLevel("ScafiBackend")
   val interpreter = new local.SimulationCommandInterpreter.JsConsole(support)

--- a/scafi-web/src/main/scala/it/unibo/scafi/js/controller/local/SimulationExecutionPlatform.scala
+++ b/scafi-web/src/main/scala/it/unibo/scafi/js/controller/local/SimulationExecutionPlatform.scala
@@ -111,8 +111,8 @@ trait SimulationExecutionPlatform extends ExecutionPlatform[SpatialSimulation#Sp
   private def remoteRequest(code : String, pathGenerator : (String) => (String)) : Future[SimulationExecution] = {
     SupportConfiguration.storeGlobal(this.systemConfig)
     CompilationServers().flatMap(servers => {
-      //val serverHost = servers.map(server).find(isReachable).getOrElse("")
-      val serverHost = server(servers.head)
+      val serverHost = servers.map(server).find(isReachable).getOrElse("")
+      //val serverHost = server(servers.head)
 
       Ajax.post(pathGenerator(serverHost), Ajax.InputData.str2ajax(code))
         .filter(_.status == 200)

--- a/scafi-web/src/main/scala/it/unibo/scafi/js/view/dynamic/EditorSection.scala
+++ b/scafi-web/src/main/scala/it/unibo/scafi/js/view/dynamic/EditorSection.scala
@@ -74,10 +74,10 @@ object EditorSection {
     case JavascriptMode.lang => JavascriptMode
   }
 
-  private class EditorSectionImpl(editorZone: Div)
+  private class EditorSectionImpl(editorZone: Div, defaultMode: Mode = ScalaModeEasy)
     extends EditorSection {
     var mode: Mode = GlobalStore.get[Mode]("mode") match {
-      case Failure(exception) => ScalaModeEasy
+      case Failure(exception) => defaultMode
       case Success(mode) => mode
     }
     private val modeSelection = new ModeSelection("editor-header", mode.lang match {


### PR DESCRIPTION
Currently there is only one server that is requested (antares.apice.unibo.it). 
If someone wants to experiment with *ScaFi Web* but the service is not available, no compilation is done.
So I have
- added localhost as another compilation service. This way it is possible to run a local compilation server with [Docker image](https://hub.docker.com/layers/138286973/gianlucaaguzzi/scafi-web/0.6.0/images/sha256-16214fa5fed93f6a7462cf96685e5f3d526c1b8ce14754acbb59d2990e5fdaa6?context=repo) and continue to use *ScaFi Web*.
- Added ScaFi.js as a scripting language (with the '?javascript' parameter in the url request).